### PR TITLE
Fix library chart URL

### DIFF
--- a/charts/elastic/Chart.yaml
+++ b/charts/elastic/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -38,4 +38,4 @@ dependencies:
     repository: https://helm.elastic.co
   - name: library-chart
     version: 1.0.3
-    repository: https://inseefrlab.github.io/helm-charts-datascience-internal
+    repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/hive-metastore/Chart.yaml
+++ b/charts/hive-metastore/Chart.yaml
@@ -25,7 +25,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -37,5 +37,5 @@ dependencies:
     repository:  https://charts.bitnami.com/bitnami
     enabled: true
   - name: library-chart
-    version: 1.0.1
-    repository: https://inseefrlab.github.io/helm-charts-datascience-internal
+    version: 1.0.3
+    repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jena/Chart.yaml
+++ b/charts/jena/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -33,4 +33,4 @@ appVersion: latest
 dependencies:
   - name: library-chart
     version: 1.0.3
-    repository: https://inseefrlab.github.io/helm-charts-datascience-internal
+    repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -35,8 +35,8 @@ dependencies:
     repository:  https://charts.bitnami.com/bitnami
     enabled: true
   - name: library-chart
-    version: 1.0.1
-    repository: https://inseefrlab.github.io/helm-charts-datascience-internal
+    version: 1.0.3
+    repository: https://inseefrlab.github.io/helm-charts-interactive-services
 
 
 

--- a/charts/lakefs/Chart.yaml
+++ b/charts/lakefs/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -35,7 +35,7 @@ dependencies:
     enabled: true
   - name: library-chart
     version: 1.0.3
-    repository: https://inseefrlab.github.io/helm-charts-datascience-internal
+    repository: https://inseefrlab.github.io/helm-charts-interactive-services
   - name: lakefs
     version: 0.5.65
     repository: https://charts.lakefs.io

--- a/charts/mariadb/Chart.yaml
+++ b/charts/mariadb/Chart.yaml
@@ -26,7 +26,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -39,4 +39,4 @@ dependencies:
     enabled: true
   - name: library-chart
     version: 1.0.3
-    repository: https://inseefrlab.github.io/helm-charts-datascience-internal
+    repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -35,5 +35,5 @@ dependencies:
     version: 12.1.21
     repository: https://charts.bitnami.com/bitnami
   - name: library-chart
-    version: 1.0.1
-    repository: https://inseefrlab.github.io/helm-charts-datascience-internal
+    version: 1.0.3
+    repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/neo4j/Chart.yaml
+++ b/charts/neo4j/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -32,4 +32,4 @@ appVersion: latest
 dependencies:
   - name: library-chart
     version: 1.0.3
-    repository: https://inseefrlab.github.io/helm-charts-datascience-internal
+    repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/nocodb/Chart.yaml
+++ b/charts/nocodb/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -32,7 +32,7 @@ appVersion: latest
 dependencies:
   - name: library-chart
     version: 1.0.3
-    repository: https://inseefrlab.github.io/helm-charts-datascience-internal
+    repository: https://inseefrlab.github.io/helm-charts-interactive-services
   - name: postgresql
     version: 11.6.15
     repository:  https://charts.bitnami.com/bitnami

--- a/charts/pgadmin/Chart.yaml
+++ b/charts/pgadmin/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -30,4 +30,4 @@ appVersion: latest
 dependencies:
   - name: library-chart
     version: 1.0.3
-    repository: https://inseefrlab.github.io/helm-charts-datascience-internal
+    repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/pinot/Chart.yaml
+++ b/charts/pinot/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -29,4 +29,4 @@ dependencies:
     enabled: true
   - name: library-chart
     version: 1.0.3
-    repository: https://inseefrlab.github.io/helm-charts-datascience-internal
+    repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/postgresql/Chart.yaml
+++ b/charts/postgresql/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -35,8 +35,8 @@ dependencies:
     repository:  https://charts.bitnami.com/bitnami
     enabled: true
   - name: library-chart
-    version: 1.0.1
-    repository: https://inseefrlab.github.io/helm-charts-datascience-internal
+    version: 1.0.3
+    repository: https://inseefrlab.github.io/helm-charts-interactive-services
 
 
 

--- a/charts/spark-history/Chart.yaml
+++ b/charts/spark-history/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -31,4 +31,4 @@ appVersion: latest
 dependencies:
   - name: library-chart
     version: 1.0.3
-    repository: https://inseefrlab.github.io/helm-charts-datascience-internal
+    repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/spark-thrift-server/Chart.yaml
+++ b/charts/spark-thrift-server/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -32,4 +32,4 @@ appVersion: "1"
 dependencies:
   - name: library-chart
     version: 1.0.3
-    repository: https://inseefrlab.github.io/helm-charts-datascience-internal
+    repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/trino/Chart.yaml
+++ b/charts/trino/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.1.1
+version: 0.1.2
 
 
 # This is the version number of the application being deployed. This version number should be
@@ -35,4 +35,4 @@ sources:
 dependencies:
   - name: library-chart
     version: 1.0.3
-    repository: https://inseefrlab.github.io/helm-charts-datascience-internal
+    repository: https://inseefrlab.github.io/helm-charts-interactive-services


### PR DESCRIPTION
Now that the library chart repo has moved, we must update every dependencies.  
:warning: I also bumped some library chart versions from `1.0.1` to `1.0.3`. Not sure if there was a specific reason to hold those versions back :warning: 