### PR TITLE
15 is new default postgres version, bumped bitnami dependency, chart is now '0.3.0'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 *.tgz
 index.yaml
 Chart.lock
-utils/prepull-deployment-manifest.yaml
-utils/prepull-daemon-manifest.yaml

--- a/charts/postgresql/Chart.yaml
+++ b/charts/postgresql/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -31,7 +31,7 @@ version: 0.2.0
 appVersion: 1
 dependencies:
   - name: postgresql
-    version: 11.9.13
+    version: 12.2.6
     repository:  https://charts.bitnami.com/bitnami
     enabled: true
   - name: library-chart

--- a/charts/postgresql/values.schema.json
+++ b/charts/postgresql/values.schema.json
@@ -13,8 +13,8 @@
             "tag": {
               "description": "postgresql major version",
               "type": "string",
-              "enum": ["10", "11", "12", "13", "14"],
-              "default": "14"
+              "enum": ["10", "11", "12", "13", "14", "15"],
+              "default": "15"
             }
           }
         },


### PR DESCRIPTION
- [bumped `bitnami/postgresql` from `11.9.13` to `12.2.6`](https://github.com/InseeFrLab/helm-charts-databases/commit/a6bc71e3ce29d281992c15d897015e1d86102e07)
- [added version 15 to postgres `default version` value in chart](https://github.com/InseeFrLab/helm-charts-databases/commit/a6bc71e3ce29d281992c15d897015e1d86102e07)
- [took out some legacy and useless .gitignore lines](https://github.com/InseeFrLab/helm-charts-databases/commit/a29d9378135fde4f79ff490fe4d11d48e411b8e4)
- bumped chart version from `0.2.0` to `0.3.0`