### PR TITLE
exit 0 even when s3/{{ .Values.s3.path }} does not exist

### DIFF
--- a/charts/pgadmin/templates/deployment.yaml
+++ b/charts/pgadmin/templates/deployment.yaml
@@ -89,8 +89,8 @@ spec:
             - -c
             - |
               mkdir /data/{{ include "pgadmin.cleanemail" . }} ;
-              MC_HOST_s3=https://$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY:$AWS_SESSION_TOKEN@$AWS_S3_ENDPOINT mc cp -r s3/{{ .Values.s3.path }} /data/{{ include "pgadmin.cleanemail" . }}         
-          envFrom:    
+              MC_HOST_s3=https://$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY:$AWS_SESSION_TOKEN@$AWS_S3_ENDPOINT mc cp -r s3/{{ .Values.s3.path }} /data/{{ include "pgadmin.cleanemail" . }} & exit 0
+          envFrom:
             - configMapRef:
                 name: {{ include "library-chart.configMapNameS3" . }}
           env:


### PR DESCRIPTION
## TLDR

Launch service even when s3 path does not exit

## The IDEA

When s3 path is enabled but the path does not really exist, the pgadmin should be still functionnal for postgres linking or other things. 

## The PR

I suggest it should exit 0 even when the s3 path does not exist.

This was tested a success